### PR TITLE
fix(android): add resolve call inside open

### DIFF
--- a/android/@teamhive/capacitor-webview-overlay/src/main/java/com/webviewOverlay/plugin/WebviewOverlayPlugin.java
+++ b/android/@teamhive/capacitor-webview-overlay/src/main/java/com/webviewOverlay/plugin/WebviewOverlayPlugin.java
@@ -242,7 +242,7 @@ public class WebviewOverlayPlugin extends Plugin {
                 else {
                     webView.loadUrl(urlString);
                 }
-
+              call.resolve();
             }
         });
     }


### PR DESCRIPTION
Right now, the call to open() never returns on Android. This PR fixes that.